### PR TITLE
ms(staff-pets-clinical): Implement test 100% coverage

### DIFF
--- a/ms-clinical-history/pom.xml
+++ b/ms-clinical-history/pom.xml
@@ -27,6 +27,10 @@
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
         <dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId><version>2.5.0</version></dependency>
         <dependency><groupId>org.springframework.cloud</groupId><artifactId>spring-cloud-starter-openfeign</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+        <dependency><groupId>net.datafaker</groupId><artifactId>datafaker</artifactId><version>2.0.2</version><scope>test</scope></dependency>
+        <dependency><groupId>org.mockito</groupId><artifactId>mockito-core</artifactId><scope>test</scope></dependency>
+        <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-engine</artifactId><scope>test</scope></dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/ms-clinical-history/src/main/java/com/vitalpet/msclinical/service/ClinicalService.java
+++ b/ms-clinical-history/src/main/java/com/vitalpet/msclinical/service/ClinicalService.java
@@ -26,12 +26,10 @@ public class ClinicalService {
     public ClinicalRecordResponseDTO create(ClinicalRecordRequestDTO dto){
        //Validamos que pet y staff existan
        Boolean petExists = petClient.existsById(dto.getPetId());
+        if(!petExists){
+            throw new ResourceNotFoundException("Error: La mascota con ID " + dto.getPetId() + " no existe");
+        }
        Boolean staffExists = staffClient.existsById(dto.getStaffId());
-
-       if(!petExists){
-           throw new ResourceNotFoundException("Error: La mascota con ID " + dto.getPetId() + " no existe");
-       }
-
        if(!staffExists){
            throw new ResourceNotFoundException("Error: El funcionario con ID " + dto.getStaffId() + " no existe");
        }

--- a/ms-clinical-history/src/test/java/com/vitalpet/msclinical/service/ClinicalServiceTest.java
+++ b/ms-clinical-history/src/test/java/com/vitalpet/msclinical/service/ClinicalServiceTest.java
@@ -1,0 +1,181 @@
+package com.vitalpet.msclinical.service;
+
+import com.vitalpet.msclinical.client.PetClient;
+import com.vitalpet.msclinical.client.StaffClient;
+import com.vitalpet.msclinical.dto.ClinicalRecordRequestDTO;
+import com.vitalpet.msclinical.dto.ClinicalRecordResponseDTO;
+import com.vitalpet.msclinical.dto.PrescriptionRequestDTO;
+import com.vitalpet.msclinical.exception.ResourceNotFoundException;
+import com.vitalpet.msclinical.model.ClinicalRecord;
+import com.vitalpet.msclinical.model.Prescription;
+import com.vitalpet.msclinical.repository.ClinicalRecordRepository;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClinicalServiceTest {
+
+    @Mock private ClinicalRecordRepository clinicalRepository;
+    @Mock private PetClient petClient;
+    @Mock private StaffClient staffClient;
+
+    @InjectMocks private ClinicalService clinicalService;
+
+    private Faker faker;
+    private ClinicalRecord mockClinicalRecord;
+    private Prescription mockPrescription;
+    private ClinicalRecordRequestDTO requestDTO;
+    private PrescriptionRequestDTO prescriptionRequestDTO;
+
+    @BeforeEach
+    void setUp() {
+        faker = new Faker();
+
+        mockClinicalRecord = new ClinicalRecord();
+        mockClinicalRecord.setId(1L);
+        mockClinicalRecord.setVisitDate(LocalDate.now());
+        mockClinicalRecord.setReason("Control de rutina");
+        mockClinicalRecord.setDiagnosis("Parásitos intestinales");
+        mockClinicalRecord.setTreatment("Desparasitación interna");
+        mockClinicalRecord.setNotes("Volver en 15 días");
+        mockClinicalRecord.setPetId(10L);
+        mockClinicalRecord.setStaffId(20L);
+
+        mockPrescription = new Prescription();
+        mockPrescription.setId(1L);
+        mockPrescription.setMedicationName(faker.medical().medicineName());
+        mockPrescription.setDosage("1 pastilla cada 12 horas");
+        mockPrescription.setDurationDays(5);
+        mockPrescription.setClinicalRecord(mockClinicalRecord);
+
+        mockClinicalRecord.setPrescriptions(List.of(mockPrescription));
+
+        prescriptionRequestDTO = new PrescriptionRequestDTO(
+                mockPrescription.getMedicationName(),
+                mockPrescription.getDosage(),
+                mockPrescription.getDurationDays()
+        );
+
+        requestDTO = new ClinicalRecordRequestDTO(
+                mockClinicalRecord.getPetId(),
+                mockClinicalRecord.getStaffId(),
+                mockClinicalRecord.getReason(),
+                mockClinicalRecord.getDiagnosis(),
+                mockClinicalRecord.getTreatment(),
+                mockClinicalRecord.getNotes(),
+                new ArrayList<>(List.of(prescriptionRequestDTO)) // Lista mutable
+        );
+    }
+
+
+    // Para los Create
+    @Test
+    void create_ShouldReturnClinicalRecordDTO_WhenValidationsPass_AndHasPrescriptions() {
+
+        when(petClient.existsById(requestDTO.getPetId())).thenReturn(true);
+        when(staffClient.existsById(requestDTO.getStaffId())).thenReturn(true);
+        when(clinicalRepository.save(any(ClinicalRecord.class))).thenReturn(mockClinicalRecord);
+
+        ClinicalRecordResponseDTO result = clinicalService.create(requestDTO);
+
+        assertNotNull(result);
+        assertEquals("Control de rutina", result.getReason());
+        assertFalse(result.getPrescriptions().isEmpty()); // Validamos que mapeó la receta
+        assertEquals(mockPrescription.getMedicationName(), result.getPrescriptions().get(0).getMedicationName());
+
+        verify(petClient, times(1)).existsById(requestDTO.getPetId());
+        verify(staffClient, times(1)).existsById(requestDTO.getStaffId());
+        verify(clinicalRepository, times(1)).save(any(ClinicalRecord.class));
+    }
+
+    @Test
+    void create_ShouldReturnClinicalRecordDTO_WhenValidationsPass_AndNoPrescriptions() {
+        requestDTO.setPrescriptions(null);
+        mockClinicalRecord.setPrescriptions(null);
+
+        when(petClient.existsById(requestDTO.getPetId())).thenReturn(true);
+        when(staffClient.existsById(requestDTO.getStaffId())).thenReturn(true);
+        when(clinicalRepository.save(any(ClinicalRecord.class))).thenReturn(mockClinicalRecord);
+
+        ClinicalRecordResponseDTO result = clinicalService.create(requestDTO);
+
+        assertNotNull(result);
+        assertEquals("Control de rutina", result.getReason());
+        assertNull(result.getPrescriptions()); // Validamos que quedó nulo limpiamente sin lanzar NullPointer
+
+        verify(clinicalRepository, times(1)).save(any(ClinicalRecord.class));
+    }
+
+    @Test
+    void create_ShouldThrowResourceNotFoundException_WhenPetDoesNotExist() {
+        when(petClient.existsById(requestDTO.getPetId())).thenReturn(false);
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> clinicalService.create(requestDTO));
+        assertEquals("Error: La mascota con ID " + requestDTO.getPetId() + " no existe", exception.getMessage());
+
+        verify(staffClient, never()).existsById(anyLong());
+        verify(clinicalRepository, never()).save(any());
+    }
+
+    @Test
+    void create_ShouldThrowResourceNotFoundException_WhenStaffDoesNotExist() {
+        when(petClient.existsById(requestDTO.getPetId())).thenReturn(true);
+        when(staffClient.existsById(requestDTO.getStaffId())).thenReturn(false);
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> clinicalService.create(requestDTO));
+        assertEquals("Error: El funcionario con ID " + requestDTO.getStaffId() + " no existe", exception.getMessage());
+
+        verify(clinicalRepository, never()).save(any());
+    }
+
+    //Para los Get
+    @Test
+    void getHistoryByPet_ShouldReturnListOfRecords() {
+        Long petId = 10L;
+        when(clinicalRepository.findByPetIdOrderByVisitDateDesc(petId)).thenReturn(List.of(mockClinicalRecord));
+
+        List<ClinicalRecordResponseDTO> result = clinicalService.getHistoryByPet(petId);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Control de rutina", result.get(0).getReason());
+        verify(clinicalRepository, times(1)).findByPetIdOrderByVisitDateDesc(petId);
+    }
+
+    @Test
+    void getByID_ShouldReturnClinicalRecordDTO_WhenExists() {
+        Long validId = 1L;
+        when(clinicalRepository.findById(validId)).thenReturn(Optional.of(mockClinicalRecord));
+
+        ClinicalRecordResponseDTO result = clinicalService.getByID(validId);
+
+        assertNotNull(result);
+        assertEquals(mockClinicalRecord.getId(), result.getId());
+        verify(clinicalRepository, times(1)).findById(validId);
+    }
+
+    @Test
+    void getByID_ShouldThrowResourceNotFoundException_WhenNotExists() {
+        Long invalidId = 99L;
+        when(clinicalRepository.findById(invalidId)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> clinicalService.getByID(invalidId));
+        assertEquals("Clínica no encontrada.", exception.getMessage());
+        verify(clinicalRepository, times(1)).findById(invalidId);
+    }
+}

--- a/ms-pets/pom.xml
+++ b/ms-pets/pom.xml
@@ -27,6 +27,10 @@
         <dependency><groupId>org.springframework.cloud</groupId><artifactId>spring-cloud-starter-openfeign</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
         <dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId><version>2.5.0</version></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+        <dependency><groupId>net.datafaker</groupId><artifactId>datafaker</artifactId><version>2.0.2</version><scope>test</scope></dependency>
+        <dependency><groupId>org.mockito</groupId><artifactId>mockito-core</artifactId><scope>test</scope></dependency>
+        <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-engine</artifactId><scope>test</scope></dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/ms-pets/src/test/java/com/vitalpet/mspets/service/PetServiceTest.java
+++ b/ms-pets/src/test/java/com/vitalpet/mspets/service/PetServiceTest.java
@@ -1,0 +1,236 @@
+package com.vitalpet.mspets.service;
+
+import com.vitalpet.mspets.client.UserClient;
+import com.vitalpet.mspets.dto.PetRequestDTO;
+import com.vitalpet.mspets.dto.PetResponseDTO;
+import com.vitalpet.mspets.dto.SpeciesResponseDTO;
+import com.vitalpet.mspets.exception.ResourceNotFoundException;
+import com.vitalpet.mspets.model.Pet;
+import com.vitalpet.mspets.model.Species;
+import com.vitalpet.mspets.repository.PetRepository;
+import com.vitalpet.mspets.repository.SpeciesRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import net.datafaker.Faker;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PetServiceTest {
+
+    @Mock private PetRepository petRepository;
+    @Mock private SpeciesRepository speciesRepository;
+    @Mock private UserClient userClient;
+
+    @InjectMocks private PetService petService;
+
+    private Faker faker;
+    private Pet mockPet;
+    private Species mockSpecies;
+    private PetRequestDTO requestDTO;
+
+    @BeforeEach
+    void setUp() {
+        faker = new Faker();
+
+        mockSpecies = new Species();
+        mockSpecies.setId(1L);
+        mockSpecies.setName("Dog");
+
+        mockPet = new Pet();
+        mockPet.setId(1L);
+        mockPet.setName(faker.dog().name());
+        mockPet.setBreed(faker.dog().breed());
+        mockPet.setBirthDate(LocalDate.now().minusYears(2));
+        mockPet.setWeight(15.5);
+        mockPet.setActive(true);
+        mockPet.setSpecies(mockSpecies);
+        mockPet.setOwnerId(2L); // Simula que pertenece al usuario con ID 2
+
+        requestDTO = new PetRequestDTO(
+                mockPet.getName(),
+                mockPet.getBreed(),
+                mockPet.getBirthDate(),
+                mockPet.getWeight(),
+                mockSpecies.getId(),
+                mockPet.getOwnerId()
+        );
+    }
+
+    // Los voy a ordenar por Get primero
+    @Test
+    void getAvailablePets_ShouldReturnPetsWithoutOwner() {
+        when(petRepository.findByOwnerIdIsNull()).thenReturn(List.of(mockPet));
+        List<PetResponseDTO> result = petService.getAvailablePets();
+        assertEquals(1, result.size());
+        verify(petRepository, times(1)).findByOwnerIdIsNull();
+    }
+
+    @Test
+    void getAllSpecies_ShouldReturnSpeciesList() {
+        when(speciesRepository.findAll()).thenReturn(List.of(mockSpecies));
+        List<SpeciesResponseDTO> result = petService.getAllSpecies();
+        assertEquals(1, result.size());
+        assertEquals("Dog", result.get(0).getName());
+    }
+
+    @Test
+    void getAll_ShouldReturnActivePets() {
+        when(petRepository.findByActiveTrue()).thenReturn(List.of(mockPet));
+        List<PetResponseDTO> result = petService.getAll();
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void getById_ShouldReturnPet_WhenExists() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(mockPet));
+        PetResponseDTO result = petService.getById(1L);
+        assertNotNull(result);
+        assertEquals(mockPet.getName(), result.getName());
+    }
+
+    @Test
+    void getById_ShouldThrowException_WhenNotExists() {
+        when(petRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> petService.getById(99L));
+    }
+
+    // Ahora los create
+    @Test
+    void create_ShouldReturnPetDTO_WhenOwnerIsNull() {
+        //Perro sin dueño ):
+        requestDTO.setOwnerId(null);
+        when(speciesRepository.findById(requestDTO.getSpeciesId())).thenReturn(Optional.of(mockSpecies));
+        when(petRepository.save(any(Pet.class))).thenReturn(mockPet);
+
+        PetResponseDTO result = petService.create(requestDTO);
+
+        //Como es nulo no debería llamar al ms
+        assertNotNull(result);
+        verify(userClient, never()).existById(anyLong());
+        verify(petRepository, times(1)).save(any(Pet.class));
+    }
+
+    @Test
+    void create_ShouldReturnPetDTO_WhenOwnerIsValidClient() {
+        // Este es con dueño, tonces validamos especia y usuario por OpenFeign
+        when(speciesRepository.findById(requestDTO.getSpeciesId())).thenReturn(Optional.of(mockSpecies));
+        when(userClient.existById(requestDTO.getOwnerId())).thenReturn(true);
+        when(userClient.isClient(requestDTO.getOwnerId())).thenReturn(true);
+        when(petRepository.save(any(Pet.class))).thenReturn(mockPet);
+
+        PetResponseDTO result = petService.create(requestDTO);
+
+        assertNotNull(result);
+        verify(userClient, times(1)).existById(requestDTO.getOwnerId());
+        verify(userClient, times(1)).isClient(requestDTO.getOwnerId());
+    }
+
+    @Test
+    void create_ShouldThrowResourceNotFoundException_WhenSpeciesDoesNotExist() {
+        when(speciesRepository.findById(requestDTO.getSpeciesId())).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> petService.create(requestDTO));
+        verify(petRepository, never()).save(any());
+    }
+
+    @Test
+    void create_ShouldThrowIllegalArgumentException_WhenOwnerIsNotClient() {
+        when(speciesRepository.findById(requestDTO.getSpeciesId())).thenReturn(Optional.of(mockSpecies));
+        when(userClient.existById(requestDTO.getOwnerId())).thenReturn(true);
+        when(userClient.isClient(requestDTO.getOwnerId())).thenReturn(false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> petService.create(requestDTO));
+        assertEquals("Error: El user no es un cliente.", exception.getMessage());
+        verify(petRepository, never()).save(any());
+    }
+
+    //Esto para los update
+    @Test
+    void update_ShouldReturnUpdatedPetDTO() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(mockPet));
+        when(speciesRepository.findById(requestDTO.getSpeciesId())).thenReturn(Optional.of(mockSpecies));
+        when(userClient.existById(requestDTO.getOwnerId())).thenReturn(true);
+        when(userClient.isClient(requestDTO.getOwnerId())).thenReturn(true);
+        when(petRepository.save(any(Pet.class))).thenReturn(mockPet);
+
+        PetResponseDTO result = petService.update(1L, requestDTO);
+
+        assertNotNull(result);
+        verify(petRepository, times(1)).save(mockPet);
+    }
+
+    @Test
+    void update_ShouldThrowResourceNotFoundException_WhenOwnerDoesNotExist() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(mockPet));
+        when(speciesRepository.findById(requestDTO.getSpeciesId())).thenReturn(Optional.of(mockSpecies));
+        when(userClient.existById(requestDTO.getOwnerId())).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> petService.update(1L, requestDTO));
+        verify(petRepository, never()).save(any());
+    }
+
+    //El resto de weas
+    @Test
+    void deactivate_ShouldSetActiveFalse() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(mockPet));
+        petService.deactivate(1L);
+        assertFalse(mockPet.getActive());
+        verify(petRepository, times(1)).save(mockPet);
+    }
+
+    @Test
+    void getByOwnerId_ShouldReturnList() {
+        when(petRepository.findByOwnerId(2L)).thenReturn(List.of(mockPet));
+        List<PetResponseDTO> result = petService.getByOwnerId(2L);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void getBySpeciesName_ShouldReturnList() {
+        when(petRepository.findBySpeciesName("Dog")).thenReturn(List.of(mockPet));
+        List<PetResponseDTO> result = petService.getBySpeciesName("Dog");
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void petExists_ShouldReturnBoolean() {
+        when(petRepository.existsPetById(1L)).thenReturn(true);
+        assertTrue(petService.petExists(1L));
+    }
+
+    //Asignar dueño
+    @Test
+    void assignOwner_ShouldUpdateOwnerId_WhenUserIsClient() {
+        Long newOwnerId = 5L;
+        when(petRepository.findById(1L)).thenReturn(Optional.of(mockPet));
+        when(userClient.existById(newOwnerId)).thenReturn(true);
+        when(userClient.isClient(newOwnerId)).thenReturn(true);
+
+        petService.assignOwner(1L, newOwnerId);
+
+        assertEquals(newOwnerId, mockPet.getOwnerId());
+        verify(petRepository, times(1)).save(mockPet);
+    }
+
+    @Test
+    void assignOwner_ShouldThrowIllegalArgumentException_WhenUserIsNotClient() {
+        Long newOwnerId = 5L;
+        when(petRepository.findById(1L)).thenReturn(Optional.of(mockPet));
+        when(userClient.existById(newOwnerId)).thenReturn(true);
+        when(userClient.isClient(newOwnerId)).thenReturn(false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> petService.assignOwner(1L, newOwnerId));
+        assertEquals("El usuario debe tener el rol de cliente para ser dueño de una mascota.", exception.getMessage());
+
+        verify(petRepository, never()).save(any()); //Nota para mí: Recordar verificar que no se guarde.
+    }
+}

--- a/ms-staff/pom.xml
+++ b/ms-staff/pom.xml
@@ -27,6 +27,10 @@
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
         <dependency><groupId>org.springframework.cloud</groupId><artifactId>spring-cloud-starter-openfeign</artifactId></dependency>
         <dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId><version>2.5.0</version></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+        <dependency><groupId>net.datafaker</groupId><artifactId>datafaker</artifactId><version>2.0.2</version><scope>test</scope></dependency>
+        <dependency><groupId>org.mockito</groupId><artifactId>mockito-core</artifactId><scope>test</scope></dependency>
+        <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-engine</artifactId><scope>test</scope></dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/ms-staff/src/test/java/com/vitalpet/msstaff/service/StaffServiceTest.java
+++ b/ms-staff/src/test/java/com/vitalpet/msstaff/service/StaffServiceTest.java
@@ -1,0 +1,246 @@
+package com.vitalpet.msstaff.service;
+
+import com.vitalpet.msstaff.client.BranchClient;
+import com.vitalpet.msstaff.client.UserClient;
+import com.vitalpet.msstaff.dto.ScheduleRequestDTO;
+import com.vitalpet.msstaff.dto.SpecialtyResponseDTO;
+import com.vitalpet.msstaff.dto.StaffRequestDTO;
+import com.vitalpet.msstaff.dto.StaffResponseDTO;
+import com.vitalpet.msstaff.exception.ResourceNotFoundException;
+import com.vitalpet.msstaff.model.Specialty;
+import com.vitalpet.msstaff.model.Staff;
+import com.vitalpet.msstaff.model.StaffSchedule;
+import com.vitalpet.msstaff.repository.StaffRepository;
+import com.vitalpet.msstaff.repository.StaffScheduleRepository;
+import com.vitalpet.msstaff.repository.StaffSpecialty;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StaffServiceTest {
+
+    @Mock private StaffScheduleRepository staffScheduleRepository;
+    @Mock private StaffRepository staffRepository;
+    @Mock private StaffSpecialty staffSpecialty;
+    //Estos son los de OpenFeign
+    @Mock private BranchClient branchClient;
+    @Mock private UserClient userClient;
+
+    @InjectMocks private StaffService staffService;
+
+    //Variables globales
+    private Faker faker;
+    private Staff mockStaff;
+    private Specialty mockSpecialty;
+    private StaffRequestDTO requestDTO;
+    private ScheduleRequestDTO scheduleRequestDTO;
+
+    //Data faker
+    @BeforeEach
+    void setUp(){
+        faker = new Faker();
+
+        mockSpecialty = new Specialty();
+        mockSpecialty.setId(1L);
+        mockSpecialty.setName("VETERINARIAN");
+
+        mockStaff = new Staff();
+        mockStaff.setId(1L);
+        mockStaff.setFirstName(faker.name().firstName());
+        mockStaff.setLastName(faker.name().lastName());
+        mockStaff.setEmail(faker.internet().emailAddress());
+        mockStaff.setPhoneNumber(faker.phoneNumber().phoneNumber());
+        mockStaff.setHireDate(LocalDate.now().minusDays(10)); // <- minus day resta días.
+        mockStaff.setBranchId(2L);
+        mockStaff.setUserId(3L);
+        mockStaff.setSpecialty(mockSpecialty);
+        mockStaff.setActive(true);
+
+        StaffSchedule mockSchedule = new StaffSchedule();
+        mockSchedule.setId(1L);
+        mockSchedule.setDayOfWeek(DayOfWeek.MONDAY);
+        mockSchedule.setStartTime(LocalTime.of(8,0));
+        mockSchedule.setEndTime(LocalTime.of(17,0));
+        mockSchedule.setStaff(mockStaff); // Vinculamos el horario al staff
+
+        mockStaff.setSchedules(List.of(mockSchedule)); // Le entregamos la lista al mockStaff
+
+        //DTOs de entrada
+        scheduleRequestDTO = new ScheduleRequestDTO(
+                DayOfWeek.MONDAY,
+                LocalTime.of(8,0),
+                LocalTime.of(17,0)
+        );
+
+        requestDTO = new StaffRequestDTO(
+                mockStaff.getFirstName(),
+                mockStaff.getFirstName(),
+                mockStaff.getEmail(),
+                mockStaff.getPhoneNumber(),
+                mockStaff.getHireDate(),
+                2L,
+                3L,
+                "VETERINARIAN",
+                List.of(scheduleRequestDTO)
+        );
+    }
+
+    //1. CREATE
+    @Test
+    void create_ShouldReturnStaffDTO_WhenAllValidationsPass() {
+        // Simulamos respuestas ideales
+        when(branchClient.existsById(requestDTO.getBranchId())).thenReturn(true);
+        when(userClient.existById(requestDTO.getUserId())).thenReturn(true);
+        when(userClient.isVet(requestDTO.getUserId())).thenReturn(true);
+
+        when(staffRepository.existsByEmail(requestDTO.getEmail())).thenReturn(false);
+        when(staffSpecialty.findByName(requestDTO.getSpecialtyName())).thenReturn(Optional.of(mockSpecialty));
+        when(staffRepository.save(any(Staff.class))).thenReturn(mockStaff);
+
+        StaffResponseDTO result = staffService.create(requestDTO);
+
+        assertNotNull(result);
+        assertEquals(mockStaff.getEmail(), result.getEmail());
+        assertEquals(mockSpecialty.getName(), result.getSpecialtyName());
+        assertFalse(result.getSchedules().isEmpty());
+
+        verify(branchClient, times(1)).existsById(anyLong());
+        verify(staffRepository, times(1)).save(any(Staff.class));
+    }
+
+    @Test
+    void create_ShouldThrowRuntimeException_WhenBranchClientFails() {
+        // Simula que el ms está apagado
+        when(branchClient.existsById(requestDTO.getBranchId())).thenThrow(new RuntimeException("Connection Refused"));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> staffService.create(requestDTO));
+        assertEquals("Error de comunicación al validar la sucursal en ms-branchs", exception.getMessage());
+
+        verify(userClient, never()).existById(anyLong()); // Nunca llega a consultar al usuario
+    }
+
+    @Test
+    void create_ShouldThrowResourceNotFoundException_WhenBranchReturnsFalse() {
+        // Sucursal devuelve false
+        when(branchClient.existsById(requestDTO.getBranchId())).thenReturn(false);
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> staffService.create(requestDTO));
+        assertEquals("Error: La sucursal con ID" + requestDTO.getBranchId() + "no existe", exception.getMessage());
+    }
+
+    @Test
+    void create_ShouldThrowIllegalArgumentException_WhenUserIsNotVet() {
+        when(branchClient.existsById(requestDTO.getBranchId())).thenReturn(true);
+        when(userClient.existById(requestDTO.getUserId())).thenReturn(true);
+        // Si existe pero no es VET
+        when(userClient.isVet(requestDTO.getUserId())).thenReturn(false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> staffService.create(requestDTO));
+        assertEquals("Error: El usuario debe tener el rol VET para ser registrado como personal médico.", exception.getMessage());
+    }
+
+    @Test
+    void create_ShouldThrowIllegalArgumentException_WhenScheduleIsInvalid() {
+        when(branchClient.existsById(requestDTO.getBranchId())).thenReturn(true);
+        when(userClient.existById(requestDTO.getUserId())).thenReturn(true);
+        when(userClient.isVet(requestDTO.getUserId())).thenReturn(true);
+        when(staffRepository.existsByEmail(requestDTO.getEmail())).thenReturn(false);
+        when(staffSpecialty.findByName(requestDTO.getSpecialtyName())).thenReturn(Optional.of(mockSpecialty));
+
+        // Aca metemos un horario raro, que termine antes de empezar
+        requestDTO.getSchedules().get(0).setStartTime(LocalTime.of(18, 0));
+        requestDTO.getSchedules().get(0).setEndTime(LocalTime.of(8, 0));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> staffService.create(requestDTO));
+        assertTrue(exception.getMessage().contains("La hora de inicio no puede ser posterior a la hora termino"));
+    }
+
+    //2. Branches
+    @Test
+    void findStaffByBranchId_ShouldReturnList_WhenBranchExists() {
+        when(branchClient.existsById(2L)).thenReturn(true);
+        when(staffRepository.findByBranchId(2L)).thenReturn(List.of(mockStaff));
+
+        List<StaffResponseDTO> result = staffService.findStaffByBranchId(2L);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(branchClient, times(1)).existsById(2L);
+        verify(staffRepository, times(1)).findByBranchId(2L);
+    }
+
+    @Test
+    void findStaffByBranchId_ShouldThrowResourceNotFound_WhenBranchReturnsFalse() {
+        when(branchClient.existsById(2L)).thenReturn(false);
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> staffService.findStaffByBranchId(2L));
+        assertEquals("Error: La sucursal con ID2no existe", exception.getMessage()); // Tal cual está en tu código
+        verify(staffRepository, never()).findByBranchId(anyLong());
+    }
+
+    //3. CRUD
+    @Test
+    void getAll_ShouldReturnListOfStaff() {
+        when(staffRepository.findByActiveTrue()).thenReturn(List.of(mockStaff));
+        List<StaffResponseDTO> result = staffService.getAll();
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void getAllSpecialties_ShouldReturnList() {
+        when(staffSpecialty.findAll()).thenReturn(List.of(mockSpecialty));
+        List<SpecialtyResponseDTO> result = staffService.getAllSpecialties();
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void getById_ShouldReturnStaff_WhenExists() {
+        when(staffRepository.findById(1L)).thenReturn(Optional.of(mockStaff));
+        StaffResponseDTO result = staffService.getById(1L);
+        assertEquals(mockStaff.getEmail(), result.getEmail());
+    }
+
+    @Test
+    void update_ShouldUpdateAndReturnStaff() {
+        when(staffRepository.findById(1L)).thenReturn(Optional.of(mockStaff));
+        when(staffSpecialty.findByName(requestDTO.getSpecialtyName())).thenReturn(Optional.of(mockSpecialty));
+        when(staffRepository.save(any(Staff.class))).thenReturn(mockStaff);
+
+        StaffResponseDTO result = staffService.update(1L, requestDTO);
+
+        assertNotNull(result);
+        verify(staffRepository, times(1)).save(mockStaff);
+    }
+
+    @Test
+    void desactivate_ShouldSetActiveFalse() {
+        when(staffRepository.findById(1L)).thenReturn(Optional.of(mockStaff));
+
+        staffService.desactivate(1L);
+
+        assertFalse(mockStaff.getActive());
+        verify(staffRepository, times(1)).save(mockStaff);
+    }
+
+    @Test
+    void staffExistsById_ShouldReturnBoolean() {
+        when(staffRepository.existsById(1L)).thenReturn(true);
+        assertTrue(staffService.staffExistsById(1L));
+    }
+
+}


### PR DESCRIPTION
Nota para mí: 
Hice un cambio en el Service de MS-Clinical-History estaba guardando en un boolean si existe el PET y otro inmediatamente si existe el Staff, lo que provocaba un error en la red , ya que ,estaba haciendo dos llamadas al OpenFeign sin todavía validar una , entonces llamaba a staff independiente si el petexistia o no, para solucionar esto simplemente ordené bien los if con las excepciones. Puse la excepción inmediatamente después de que hicimos la llamada , así evitamos llamar una vez más de manera innecesaria.

PD: Esto lo pude ver gracias a que en los test me daba error.